### PR TITLE
ci: update third-party actions to node 24

### DIFF
--- a/.github/workflows/index-latest.yml
+++ b/.github/workflows/index-latest.yml
@@ -17,10 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install minimal stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
+      uses: dtolnay/rust-toolchain@stable
     - name: Set up Python 3.10
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:


### PR DESCRIPTION
Replace archived actions-rs/toolchain (node12) with dtolnay/rust-toolchain. GitHub will force all actions to Node 24 on June 2, 2026.